### PR TITLE
Fix build on nightly

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -118,7 +118,7 @@ macro_rules! semop_lock {
     ($id: expr) => ({
         semop!($id, true)
     });
-    ($id: expr, $index) => ({
+    ($id: expr, $index: expr) => ({
         semop!($id, $index, true)
     });
     ($id: expr, $index: expr, $nbop: expr) => ({
@@ -133,7 +133,7 @@ macro_rules! semop_unlock {
     ($id: expr) => ({
         semop!($id, false)
     });
-    ($id: expr, $index) => ({
+    ($id: expr, $index: expr) => ({
         semop!($id, $index, false)
     });
     ($id: expr, $index: expr, $nbop: expr) => ({


### PR DESCRIPTION
Hi.

https://github.com/rust-lang/rust/pull/42894 makes some compatibility lints in `rustc` deny-by-default and regression testing found that this crate is affected. Here's a patch fixing the deprecated code (see https://github.com/rust-lang/rust/issues/40107 for more information about the issue).
